### PR TITLE
autoset primary-email

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -31,7 +31,6 @@ config :rivet_ident,
   notify_user_failed_change: Rivet.Ident.User.Notify.UserFailedChange,
   notify_user_verification: Rivet.Ident.User.Notify.UserVerification
 
-
 # to keep the compiling functional, even if it doesn't work
 config :rivet_email,
   enabled: false,

--- a/lib/ident/user/lib/index.ex
+++ b/lib/ident/user/lib/index.ex
@@ -129,10 +129,13 @@ defmodule Rivet.Ident.User.Lib do
         {:error, "That email already is associated with a different account"}
 
       {:error, _} ->
+        has_email? = not Ident.Email.exists?(user_id: user.id)
+
         # add it
         case Ident.Email.create(%{
                user_id: user.id,
                verified: verified,
+               primary: not has_email?,
                address: eaddr
              }) do
           {:ok, %Ident.Email{} = email} ->

--- a/lib/ident/user/notify/password_reset.ex
+++ b/lib/ident/user/notify/password_reset.ex
@@ -7,7 +7,10 @@ defmodule Rivet.Ident.User.Notify.PasswordReset do
   # preload to send to all and not filter verified
   def sendto(%Ident.User{} = user, %Ident.Email{} = email, %Ident.UserCode{} = code) do
     with {:ok, user} <- Ident.User.preload(user, [:emails]) do
-      Rivet.Email.mailer().sendto(user.emails, __MODULE__, reqaddr: email.address, code: code.code)
+      Rivet.Email.mailer().sendto(user.emails, __MODULE__,
+        reqaddr: email.address,
+        code: code.code
+      )
     end
   end
 end

--- a/test/auth/signin_local_test.exs
+++ b/test/auth/signin_local_test.exs
@@ -11,95 +11,94 @@ defmodule Rivet.Ident.Test.Signin.LocalTest do
 
   test "Signin Local" do
     # assert capture_log(fn ->
-             # Signup
-             assert {:error,
-                     %Auth.Domain{
-                       log: "Auth signup failed, arguments don't match",
-                       error: "Signup Failed"
-                     }} = Local.signup("example.com", "narf")
+    # Signup
+    assert {:error,
+            %Auth.Domain{
+              log: "Auth signup failed, arguments don't match",
+              error: "Signup Failed"
+            }} = Local.signup("example.com", "narf")
 
-             user_pass = "VFR$#EDCvfr43edc"
-             user_handle = "narf"
-             user_email = "narf@narf.com"
+    user_pass = "VFR$#EDCvfr43edc"
+    user_handle = "narf"
+    user_email = "narf@narf.com"
 
-             good_user = %{
+    good_user = %{
+      "handle" => user_handle,
+      "password" => user_pass,
+      "email" => user_email
+    }
+
+    assert {:ok, %Auth.Domain{status: :authed, user: user}} =
+             Local.signup("example.com", good_user)
+
+    user_id = user.id
+    error = "A signin already exists for `#{user_email}`"
+
+    assert {:error, %Auth.Domain{error: ^error}} = Local.signup("example.com", good_user)
+
+    # Check
+    assert {:ok, %Auth.Domain{status: :authed}} =
+             Local.check(%Auth.Domain{status: :narf}, %{
                "handle" => user_handle,
-               "password" => user_pass,
-               "email" => user_email
-             }
+               "password" => user_pass
+             })
 
-             assert {:ok, %Auth.Domain{status: :authed, user: user}} =
-                      Local.signup("example.com", good_user)
+    assert {:error,
+            %Auth.Domain{
+              error: "Unable to sign in. Did you want to sign up instead?",
+              log: "Cannot find person ~doctor"
+            }} =
+             Local.check(%Auth.Domain{}, %{"handle" => "doctor", "password" => "who"})
 
-             user_id = user.id
-             error = "A signin already exists for `#{user_email}`"
+    assert {:error, _} =
+             Local.check("hostname", %{"handle" => "doctor", "password" => "who"})
 
-             assert {:error, %Auth.Domain{error: ^error}} = Local.signup("example.com", good_user)
+    # Load user
+    assert {:error, %{log: "Cannot find email red@narf"}} =
+             Local.load_user({:ok, %Auth.Domain{}}, "red@narf")
 
-             # Check
-             assert {:ok, %Auth.Domain{status: :authed}} =
-                      Local.check(%Auth.Domain{status: :narf}, %{
-                        "handle" => user_handle,
-                        "password" => user_pass
-                      })
+    assert {:error, %{log: "Cannot find person ~red"}} =
+             Local.load_user({:ok, %Auth.Domain{}}, "red")
 
-             assert {:error,
-                     %Auth.Domain{
-                       error: "Unable to sign in. Did you want to sign up instead?",
-                       log: "Cannot find person ~doctor"
-                     }} =
-                      Local.check(%Auth.Domain{}, %{"handle" => "doctor", "password" => "who"})
+    assert {:ok, %{user: %Ident.User{id: ^user_id}}} =
+             Local.load_user({:ok, %Auth.Domain{}}, user_email)
 
-             assert {:error, _} =
-                      Local.check("hostname", %{"handle" => "doctor", "password" => "who"})
+    # Load password factor
+    newu = insert(:ident_user)
 
-             # Load user
-             assert {:error, %{log: "Cannot find email red@narf"}} =
-                      Local.load_user({:ok, %Auth.Domain{}}, "red@narf")
+    assert {:error, %Auth.Domain{log: "No auth factor for user"}} =
+             Local.load_password_factor({:ok, %Auth.Domain{user: newu}})
 
-             assert {:error, %{log: "Cannot find person ~red"}} =
-                      Local.load_user({:ok, %Auth.Domain{}}, "red")
+    #
+    # # Check password
+    # password = "Bad Wolf"
+    # hashed = Utils.Hash.password(password)
+    # assert true == Local.check_password(hashed, password)
+    # assert false == Local.check_password(hashed, "Time Lord")
+    assert true == Local.check_password(user, user_pass)
+    assert false == Local.check_password(newu, "not")
+    assert false == Local.check_password(:bork, nil)
 
-             assert {:ok, %{user: %Ident.User{id: ^user_id}}} =
-                      Local.load_user({:ok, %Auth.Domain{}}, user_email)
+    # valid_user_factor
 
-             # Load password factor
-             newu = insert(:ident_user)
+    assert {:ok, [factor]} = Ident.Factor.all(user_id: user.id)
 
-             assert {:error, %Auth.Domain{log: "No auth factor for user"}} =
-                      Local.load_password_factor({:ok, %Auth.Domain{user: newu}})
+    assert {:error, %Auth.Domain{status: :unknown, log: "Invalid Password"}} =
+             Local.valid_user_factor(
+               {:ok, %Auth.Domain{user: user, factor: factor}},
+               "narf"
+             )
 
-             #
-             # # Check password
-             # password = "Bad Wolf"
-             # hashed = Utils.Hash.password(password)
-             # assert true == Local.check_password(hashed, password)
-             # assert false == Local.check_password(hashed, "Time Lord")
-             assert true == Local.check_password(user, user_pass)
-             assert false == Local.check_password(newu, "not")
-             assert false == Local.check_password(:bork, nil)
+    assert {:error, %Auth.Domain{status: :unknown, log: "No password factor exists for user"}} =
+             Local.valid_user_factor({:ok, %Auth.Domain{user: user}}, user_pass)
 
-             # valid_user_factor
+    assert {:ok, %Auth.Domain{status: :authed}} =
+             Local.valid_user_factor(
+               {:ok, %Auth.Domain{user: user, factor: factor}},
+               user_pass
+             )
 
-             assert {:ok, [factor]} = Ident.Factor.all(user_id: user.id)
-
-             assert {:error, %Auth.Domain{status: :unknown, log: "Invalid Password"}} =
-                      Local.valid_user_factor(
-                        {:ok, %Auth.Domain{user: user, factor: factor}},
-                        "narf"
-                      )
-
-             assert {:error,
-                     %Auth.Domain{status: :unknown, log: "No password factor exists for user"}} =
-                      Local.valid_user_factor({:ok, %Auth.Domain{user: user}}, user_pass)
-
-             assert {:ok, %Auth.Domain{status: :authed}} =
-                      Local.valid_user_factor(
-                        {:ok, %Auth.Domain{user: user, factor: factor}},
-                        user_pass
-                      )
-
-             # assert :narf = Local.valid_user_factor({:ok, %Auth.Domain{}}, "narf")
-           # end) =~ "Signin Success"
+    # assert :narf = Local.valid_user_factor({:ok, %Auth.Domain{}}, "narf")
+    # end) =~ "Signin Success"
   end
 end


### PR DESCRIPTION
- runs `mix format`
- adds `primary` field when adding email

I linked the dep locally and tested that primary=true is set for signing up both with email and pw/username. I also added a new email from preferences and confirmed it set primary=false.

## ticket
https://cato-digital.atlassian.net/browse/CD-2907