### PR TITLE
user search bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ old
 /**/_build
 # The directory Mix downloads your dependencies sources to.
 /**/deps
+deps
+_build
 # Also ignore archive artifacts (built via "mix archive.build").
 /**/*.ez
 # If you run "mix test --cover", coverage assets end up here.

--- a/lib/ident/user/lib/index.ex
+++ b/lib/ident/user/lib/index.ex
@@ -12,7 +12,7 @@ defmodule Rivet.Ident.User.Lib do
       on: e.user_id == u.id,
       join: h in Ident.Handle,
       on: h.user_id == u.id,
-      where: like(u.name, ^match) or like(h.handle, ^match) or like(e.address, ^match)
+      where: ilike(u.name, ^match) or like(h.handle, ^match) or like(e.address, ^match)
     )
     |> Rivet.Ecto.Collection.enrich_query_args(args)
     |> Rivet.Ident.User.all()

--- a/test/auth/signin_local_test.exs
+++ b/test/auth/signin_local_test.exs
@@ -47,11 +47,9 @@ defmodule Rivet.Ident.Test.Signin.LocalTest do
             %Auth.Domain{
               error: "Unable to sign in. Did you want to sign up instead?",
               log: "Cannot find person ~doctor"
-            }} =
-             Local.check(%Auth.Domain{}, %{"handle" => "doctor", "password" => "who"})
+            }} = Local.check(%Auth.Domain{}, %{"handle" => "doctor", "password" => "who"})
 
-    assert {:error, _} =
-             Local.check("hostname", %{"handle" => "doctor", "password" => "who"})
+    assert {:error, _} = Local.check("hostname", %{"handle" => "doctor", "password" => "who"})
 
     # Load user
     assert {:error, %{log: "Cannot find email red@narf"}} =

--- a/test/ident/user/user_test.exs
+++ b/test/ident/user/user_test.exs
@@ -47,4 +47,16 @@ defmodule Rivet.Ident.Test.UserTest do
       assert deleted.id == model.id
     end
   end
+
+  describe "lib" do
+    test "search" do
+      name = "RICHTHOFEN"
+      user = insert(:ident_user, name: name)
+      insert(:ident_handle, user: user)
+      insert(:ident_email, user: user)
+
+      assert {:ok, [%Rivet.Ident.User{name: ^name}]} =
+               Rivet.Ident.User.Lib.search(%{matching: String.downcase(name)}, [])
+    end
+  end
 end


### PR DESCRIPTION
- user.name is `varchar` not `citext` so `like` will not work reliably especially given we downcase matching input.